### PR TITLE
chore: rename ci jobs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: Validate Docker Compose Stacks
+name: check
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - '**/*-compose.ya?ml'
 
 jobs:
-  validate:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -18,4 +18,4 @@ jobs:
       - name: Validate Docker Compose files
         uses: docker/compose@v1
         with:
-          files: '**/*-compose.ya?ml'
+          files: 'hosts/*-compose.ya?ml'


### PR DESCRIPTION
Update GitHub Actions workflow to validate Docker Compose files.

* Change the job name from `validate` to `docker`.
* Update the file path pattern for Docker Compose validation to `hosts/*-compose.ya?ml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nsheaps/portainer-stacks/pull/2?shareId=c8beeb9c-d8dd-4e6c-a071-d848863fbd53).